### PR TITLE
Add YouTube outage of November 11

### DIFF
--- a/outages-1.json
+++ b/outages-1.json
@@ -29,7 +29,7 @@
 	},
 	{
 		"name": "YouTube",
-		"link": ""
+		"link": "https://www.theverge.com/2020/11/11/21561764/youtube-down-outage-loading-videos"
 	},
 	{
 		"name": "Reddit",


### PR DESCRIPTION
Official tweets: https://twitter.com/TeamYouTube/status/1326709701526974464