### PR TITLE
Add encoding to fix confetti emoji

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
 	<head>
 		<title>Major Breach and Outage Bingo</title>
+		<meta charset="utf-8">
 		<script src="https://cdn.jsdelivr.net/npm/js-confetti@latest/dist/js-confetti.browser.js"></script>
 		<style type="text/css">
 			body {


### PR DESCRIPTION
While I’ve found the misencoded confetti charming, I was able to specify an encoding in the HTML to have the emoji render properly. Before:

![confetti-broken](https://user-images.githubusercontent.com/43280/143267455-b20bb8dc-0c6e-49a0-83fd-6f00ad8d6c60.gif)

After:

![confetti-working](https://user-images.githubusercontent.com/43280/143267564-a12088ef-8212-46ef-99ba-6f8e5e52f4a3.gif)
