### PR TITLE
Add Slack and Coinbase outages

### DIFF
--- a/outages-2.json
+++ b/outages-2.json
@@ -1,11 +1,11 @@
 [
 	{
 		"name": "Slack",
-		"link": ""
+		"link": "https://status.slack.com/2021-12/f756fef8e8c0c05b"
 	},
 	{
 		"name": "A major cryptocurrency service",
-		"link": ""
+		"link": "https://status.coinbase.com/incidents/p2hj1rc6l4h1"
 	},
 	{
 		"name": "A major ISP / telecom company",


### PR DESCRIPTION
Note that Coinbase is currently experiencing two separate outages.