### PR TITLE
Add Google Calendar outage of December 8

### DIFF
--- a/outages-2.json
+++ b/outages-2.json
@@ -17,7 +17,7 @@
 	},
 	{
 		"name": "Google (main servers)",
-		"link": ""
+		"link": "https://www.google.com/appsstatus/dashboard/incidents/zURR7mGQjom4ktGZcR5A"
 	},
 	{
 		"name": "Twitter",


### PR DESCRIPTION
At least Google Calendar was broken (500 errors).