### PR TITLE
ATO Online breach

### DIFF
--- a/outages-2.json
+++ b/outages-2.json
@@ -49,7 +49,7 @@
 	},
 	{
 		"name": "A government entity",
-		"link": ""
+		"link": "https://www.itnews.com.au/news/sa-gov-employee-data-stolen-in-frontier-software-ransomware-attack-573880"
 	},
 	{
 		"name": "A large DNS provider",

--- a/outages-3.json
+++ b/outages-3.json
@@ -49,7 +49,7 @@
 	},
 	{
 		"name": "A government entity",
-		"link": ""
+		"link": "https://www.itnews.com.au/news/tens-of-thousands-locked-out-of-ato-online-accounts-after-payroll-hack-574194"
 	},
 	{
 		"name": "A large DNS provider",


### PR DESCRIPTION
Source: https://www.itnews.com.au/news/tens-of-thousands-locked-out-of-ato-online-accounts-after-payroll-hack-574194