### PR TITLE
Add DNSSEC incident

### DIFF
--- a/outages-4.json
+++ b/outages-4.json
@@ -81,7 +81,7 @@
 	},
 	{
 		"name": "An entire TLD",
-		"link": ""
+		"link": "https://internetstiftelsen.se/pagaende-problem-se-domaner/"
 	},
 	{
 		"name": "Other major CDN provider (Fastly, Akamai, etc.)",


### PR DESCRIPTION
The .se TLD is currently experiencing an issue where malformed DNSSEC signatures were issued for a decent amount of domains. I'm not sure if this counts as an outage - especially as many smaller resolvers don't handle DNSSEC properly - so feel free to close if you feel it's not in scope.