### PR TITLE
Strike off GCP

### DIFF
--- a/outages-5.json
+++ b/outages-5.json
@@ -73,7 +73,7 @@
 	},
 	{
 		"name": "Google Cloud Platform",
-		"link": ""
+		"link": "https://news.ycombinator.com/item?id=30603574"
 	},
 	{
 		"name": "Microsoft (main servers)",


### PR DESCRIPTION
Hacker News is a reputable source.