### PR TITLE
Add .fi DNSSEC incident

### DIFF
--- a/outages-5.json
+++ b/outages-5.json
@@ -81,7 +81,7 @@
 	},
 	{
 		"name": "An entire TLD",
-		"link": ""
+		"link": "https://news.ycombinator.com/item?id=30596404"
 	},
 	{
 		"name": "Other major CDN provider (Fastly, Akamai, etc.)",


### PR DESCRIPTION
Not reported on by any news agencies that I can tell, but an outage nonetheless.