### PR TITLE
Add Contabo outage

### DIFF
--- a/outages-5.json
+++ b/outages-5.json
@@ -16,8 +16,8 @@
 		"link": ""
 	},
 	{
-		"name": "Google (main servers)",
-		"link": ""
+		"name": "Other cloud providers",
+		"link": "https://web.archive.org/web/20220311235424/https://contabo-status.com/"
 	},
 	{
 		"name": "Twitter",


### PR DESCRIPTION
Per suggestion, this additionally changes "Google (main servers)" -> "Other cloud providers". Maybe something else exciting will occur this month!