### PR TITLE
Add PyPI outage

### DIFF
--- a/outages-8.json
+++ b/outages-8.json
@@ -65,7 +65,7 @@
 	},
 	{
 		"name": "A major code hosting service (Github, PyPI, NPM, etc.)",
-		"link": ""
+		"link": "https://status.python.org/incidents/l16ylxktn4r9"
 	},
 	{
 		"name": "Apple",


### PR DESCRIPTION
The status page downplays it a little bit but pip runs into 503 trying to install anything.

![PyPI screenshot](https://user-images.githubusercontent.com/426784/176005719-6cc3c6b1-cbb3-440a-80db-0ba49aff7e5e.png)

edit: They added "has caused our backends to become unhealthy, affecting all web traffic"