### PR TITLE
Add GitHub outage

### DIFF
--- a/outages-11.json
+++ b/outages-11.json
@@ -65,7 +65,7 @@
 	},
 	{
 		"name": "A major code hosting service (Github, PyPI, NPM, etc.)",
-		"link": ""
+		"link": "https://www.githubstatus.com/incidents/cwp52gsftl5n"
 	},
 	{
 		"name": "Apple",


### PR DESCRIPTION
Really this is the 6th GitHub outage this month :sweat_smile:

![screenshot of GitHub's Status website](https://user-images.githubusercontent.com/426784/188919271-bea16d8c-b2c3-4d36-a65b-01378ba18a06.png)
