### PR TITLE
Add Slack and Instagram outages

### DIFF
--- a/outages-19.json
+++ b/outages-19.json
@@ -1,7 +1,7 @@
 [
 	{
 		"name": "Slack",
-		"link": ""
+		"link": "https://status.slack.com/2023-05-17"
 	},
 	{
 		"name": "A major cryptocurrency service",
@@ -61,7 +61,7 @@
 	},
 	{
 		"name": "Facebook / WhatsApp / Instagram",
-		"link": ""
+		"link": "https://www.theverge.com/2023/5/21/23732173/instagram-down-outage-not-loading"
 	},
 	{
 		"name": "A major code hosting service (Github, PyPI, NPM, etc.)",


### PR DESCRIPTION
- https://status.slack.com/2023-05-17
- https://www.theverge.com/2023/5/21/23732173/instagram-down-outage-not-loading